### PR TITLE
Fix pricing page routing

### DIFF
--- a/src/controllers/pricing.rs
+++ b/src/controllers/pricing.rs
@@ -3,7 +3,7 @@ use rocket_dyn_templates::{context, Template};
 #[get("/pricing")]
 pub fn pricing() -> Template {
     Template::render(
-        "pricing",
+        "pages/pricing",
         context! {
             title: "Our Services & Pricing",
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ fn rocket() -> _ {
     let rocket = rocket::build()
         .attach(DbConn::fairing())
         .mount("/static", FileServer::from(relative!("static")))
+        .mount("/pricing", routes![controllers::pricing::pricing])
         .register(
             "/",
             catchers![

--- a/templates/pages/pricing.html.hbs
+++ b/templates/pages/pricing.html.hbs
@@ -165,4 +165,4 @@
         });
     </script>
 {{/inline}}
-{{~> layouts/base title="Automatic Homework Completion Subscriptions"~}}
+{{~> layouts/base title="Our Services & Pricing"~}}


### PR DESCRIPTION
Update routing and template for the pricing page.

* Change `Template::render` call in `src/controllers/pricing.rs` to use `pages/pricing` instead of `pricing`.
* Update the title in `templates/pages/pricing.html.hbs` to "Our Services & Pricing".
* Add a mount for the pricing page in `src/main.rs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdntNinja/Rust-web?shareId=XXXX-XXXX-XXXX-XXXX).