### PR TITLE
Fix Cookie::build function calls and deprecated usage

### DIFF
--- a/src/controllers/auth.rs
+++ b/src/controllers/auth.rs
@@ -46,7 +46,7 @@ pub async fn process_login(
     match result {
         Ok(user) => {
             // Set session cookie
-            let cookie = Cookie::build("user_id", user.id.to_string())
+            let cookie = Cookie::build("user_id")
                 .path("/")
                 .build();
             cookies.add_private(cookie);
@@ -67,7 +67,7 @@ pub async fn process_login(
 
 #[get("/logout")]
 pub fn logout(cookies: &CookieJar<'_>) -> Redirect {
-    cookies.remove_private(Cookie::named("user_id"));
+    cookies.remove_private(Cookie::from("user_id"));
     Redirect::to("/")
 }
 
@@ -100,7 +100,7 @@ pub async fn process_signup(
     match result {
         Ok(user) => {
             // Set session cookie
-            let cookie = Cookie::build("user_id", user.id.to_string())
+            let cookie = Cookie::build("user_id")
                 .path("/")
                 .build();
             cookies.add_private(cookie);


### PR DESCRIPTION
Fix the compilation errors in `src/controllers/auth.rs`.

* **Update `Cookie::build` calls:**
  - Change `Cookie::build("user_id", user.id.to_string())` to `Cookie::build("user_id")` in two places.

* **Replace deprecated `Cookie::named`:**
  - Change `Cookie::named("user_id")` to `Cookie::from("user_id")` in the `logout` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KdntNinja/Rust-web/pull/5?shareId=bc1f5bda-16f1-4851-92c5-1d3d9aff3811).